### PR TITLE
Fix window leak

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,14 @@ exports.main = function (options, callbacks) {
 		GLOBAL_SCOPE["vt"+windowID] = new VerticalTabsReloaded(lowLevelWindow);
 		unload(GLOBAL_SCOPE["vt"+windowID].unload.bind(GLOBAL_SCOPE["vt"+windowID]), lowLevelWindow);
 	});
-	
+
+	windows.browserWindows.on('close', function(window) {
+		let lowLevelWindow = viewFor(window);
+		let windowID = windowUtils.getOuterId(lowLevelWindow);
+		GLOBAL_SCOPE["vt"+windowID].unload();
+		delete GLOBAL_SCOPE["vt"+windowID];
+	});
+
 	initHotkeys();
 	
 	simplePrefs.on("toggleDisplayHotkey", function(prefName) { GLOBAL_SCOPE.vtToggleDisplayHotkey.destroy(); initHotkeys(); });

--- a/lib/verticaltabs.js
+++ b/lib/verticaltabs.js
@@ -221,9 +221,10 @@ VerticalTabsReloaded.prototype = {
 
 	observePrefs: function() {
 		let vt = this;
-		simplePrefs.on("", function(prefName) { vt.onPreferenceChange(prefName, vt); });
+		function onChange(prefName) { vt.onPreferenceChange(prefName, vt); }
+		simplePrefs.on("", onChange);
 		this.unloaders.push(function() {
-			simplePrefs.on("", function(prefName) { vt.onPreferenceChange(prefName, vt); });
+			simplePrefs.off("", onChange);
 		});
 	},
 


### PR DESCRIPTION
Currently if you open a lot of windows in Firefox with this extension loaded, they leak. Example:

1. Open Firefox with Vertical Tabs Reloaded installed.
2. Hit Ctrl-N followed by Ctrl-W 10 or 20 times.
3. Go to about:memory and push "Minimize memory usage". Then press "Measure" with it's done.
4. Notice a lot of window-objects listed as "top(none)/detached". These are all leaked browser windows. The more you hit Ctrl-N/Ctrl-W, the larger this number will grow. It never decreases.

My patch causes the add-on to release references to windows when they're closed so that the memory can be freed.