### PR TITLE
Ensure that we have selected tab before removing "selected" attribute

### DIFF
--- a/webextension/lib.js
+++ b/webextension/lib.js
@@ -377,7 +377,8 @@ var VerticalTabsReloaded = class VerticalTabsReloaded
             case "selected":
                 if(this.selectedTabID != undefined)
                 {
-                    this.document.getElementById("tab-" + this.selectedTabID).removeAttribute("selected");
+                    let tab = this.document.getElementById("tab-" + this.selectedTabID);
+                    if(tab) { tab.removeAttribute("selected"); }
                 }
 
                 let selectedTab = this.document.getElementById("tab-" + tabID);


### PR DESCRIPTION
Sometimes there is no tab with `[selected="true"]` even though `this.selectedTabID` is defined, so we have:
```
11:46:52.060 this.document.getElementById(...) is null 1 lib.js:355
	update_tab moz-extension://093ec84a-4d75-4e70-9bf9-7d5f30ecd9e5/lib.js:355:21
	initEventListeners/< moz-extension://093ec84a-4d75-4e70-9bf9-7d5f30ecd9e5/lib.js:540:13
	apply self-hosted:4154:5
	applySafeWithoutClone resource://gre/modules/ExtensionCommon.jsm:283:16
	runSafeWithoutClone resource://gre/modules/ExtensionCommon.jsm:255:12
	fire resource://gre/modules/ExtensionChild.jsm:831:71
	receiveMessage resource://gre/modules/ExtensionChild.jsm:833:76
	_callHandlers/< resource://gre/modules/MessageChannel.jsm:655:17
	_callHandlers resource://gre/modules/MessageChannel.jsm:654:14
	_handleMessage/deferred.promise< resource://gre/modules/MessageChannel.jsm:729:7
	_handleMessage resource://gre/modules/MessageChannel.jsm:726:24
	_handleMessage self-hosted:955:17
receiveMessage resource://gre/modules/MessageChannel.jsm:159:5
```