### PR TITLE
Support following the system's dark / light theme

### DIFF
--- a/data/theme/system/index.css
+++ b/data/theme/system/index.css
@@ -1,0 +1,2 @@
+@import "../light/index.css" (prefers-color-scheme: light);
+@import "../dark/index.css" (prefers-color-scheme: dark);

--- a/options/options.json
+++ b/options/options.json
@@ -97,6 +97,10 @@
 				"label": "Light (recommended)"
 			},
 			{
+				"value": "system",
+				"label": "Follow System Theme"
+			},
+			{
 				"value": "darwin",
 				"label": "Darwin"
 			},


### PR DESCRIPTION
Add a new stylesheet that imports the dark or light theme based on the
browser's configured preference.