### PR TITLE
Prevent pinned tabs from being closed by "close all tabs ..." context menu functions

### DIFF
--- a/utils/tabs.js
+++ b/utils/tabs.js
@@ -197,9 +197,15 @@ utils["tabs"] = class tabutils
         let closeTheseTabs = [];
         for(let tab of window.document.querySelectorAll(".tabbrowser-tab"))
         {
-            if(tab.style.display == "none") { continue; }
-
             let currentTabID = this.getIDFromHTMLID(tab.id);
+            let pinned = tab.getAttribute("pinned");
+
+            if(tab.style.display == "none"
+               || pinned == "true")
+            {
+                continue;
+            }
+
             let currentTabIndex = this.getIndexFrom(currentTabID);
 
             if((relativeTyp == "below" && currentTabIndex > tabIndex)


### PR DESCRIPTION
Prevent pinned tabs from being closed when "Close All Tabs Above" or "Close All Tabs Below" is selected.